### PR TITLE
Fix [Fix embedding in new YAML grammar]

### DIFF
--- a/utilities/syntax_templates/yaml_syntax.js
+++ b/utilities/syntax_templates/yaml_syntax.js
@@ -26,7 +26,7 @@ export function buildYamlSyntax(hostSpec, embeddedSpecs) {
         'end': String.raw`^(?=\S)|(?!\G)`,
         'patterns': [
             {
-                'begin': String.raw`(?>^|\\G)([ ]+)(?! )`,
+                'begin': String.raw`(?>^|\G)([ ]+)(?! )`,
                 'end': String.raw`^(?!\1|\s*$)`,
                 'patterns': [{ 'include': `${embedded.root_scope}` }],
                 'name': `meta.embedded.block.${embedded.vsname}.${hostSpec.vsname} ${embedded.root_scope}`,


### PR DESCRIPTION
Fixes mistake in https://github.com/ruschaaf/extended-embedded-languages/pull/17#issuecomment-2323109273
should have only been single escaped
`\\G` => `\G`

![image](https://github.com/user-attachments/assets/973c996e-d7c1-4ab9-a2b7-fdb2b7f239c1)
```yaml
test: | #js
  console.log("hello world")
  console.log("hello world")

---

nested:
  test: | #js
    console.log("hello world")
    console.log("hello world")

---

| #js
  console.log("hello world")
  console.log("hello world")
```